### PR TITLE
Add sorting and filtering for posts list

### DIFF
--- a/Client/src/components/postsList/PostsList.jsx
+++ b/Client/src/components/postsList/PostsList.jsx
@@ -7,17 +7,29 @@ const PostsList = () => {
   const { currentUser } = useCurrentUser();
   const [posts, setPosts] = useState([]);
   const [error, setError] = useState(null);
-debugger
+  const [sort, setSort] = useState('date');
+  const [griefTag, setGriefTag] = useState('');
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [likedOnly, setLikedOnly] = useState(false);
+  const [mineOnly, setMineOnly] = useState(false);
   useEffect(() => {
-    // fetch('http://localhost:3000/posts')
-       const token = localStorage.getItem('token');
-    fetch('http://localhost:3000/posts', {
+    const token = localStorage.getItem('token');
+    const params = new URLSearchParams();
+    params.append('sort', sort);
+    if (griefTag) params.append('grief_tag', griefTag);
+    if (startDate) params.append('startDate', startDate);
+    if (endDate) params.append('endDate', endDate);
+    if (likedOnly) params.append('liked', 'true');
+    if (mineOnly) params.append('mine', 'true');
+
+    fetch(`http://localhost:3000/posts?${params.toString()}`, {
       headers: { 'Authorization': `Bearer ${token}` }
     })
       .then(res => res.json())
       .then(data => setPosts(data))
       .catch(err => setError(err.message));
-  }, []);
+  }, [sort, griefTag, startDate, endDate, likedOnly, mineOnly]);
 
   const handleDelete = (id) => {
     setPosts(posts.filter(p => p.id !== id));
@@ -27,6 +39,47 @@ debugger
     <>
       <Nav />
       <h2>Posts</h2>
+      <div className="filters">
+        <label>
+          Sort by:
+          <select value={sort} onChange={e => setSort(e.target.value)}>
+            <option value="date">Date</option>
+            <option value="popularity">Popularity</option>
+          </select>
+        </label>
+        <label>
+          Tag:
+          <select value={griefTag} onChange={e => setGriefTag(e.target.value)}>
+            <option value="">All</option>
+            <option value="Parent">Parent</option>
+            <option value="Sibling">Sibling</option>
+            <option value="Spouse">Spouse</option>
+            <option value="Child">Child</option>
+            <option value="Friend">Friend</option>
+            <option value="Grandparent">Grandparent</option>
+            <option value="In-Law">In-Law</option>
+            <option value="Cousin">Cousin</option>
+            <option value="Distant Relative">Distant Relative</option>
+            <option value="Other">Other</option>
+          </select>
+        </label>
+        <label>
+          From:
+          <input type="date" value={startDate} onChange={e => setStartDate(e.target.value)} />
+        </label>
+        <label>
+          To:
+          <input type="date" value={endDate} onChange={e => setEndDate(e.target.value)} />
+        </label>
+        <label>
+          <input type="checkbox" checked={likedOnly} onChange={e => setLikedOnly(e.target.checked)} />
+          Only with likes
+        </label>
+        <label>
+          <input type="checkbox" checked={mineOnly} onChange={e => setMineOnly(e.target.checked)} />
+          My posts
+        </label>
+      </div>
       {/* {error && <p>{error}</p>} */}
       {posts.map(post => (
         <SinglePost key={post.id} post={post} onDelete={() => handleDelete(post.id)} />

--- a/Server/Controllers/Posts.js
+++ b/Server/Controllers/Posts.js
@@ -1,10 +1,28 @@
 
 import * as postService from '../Services/Posts.js';
 
- export async function getPosts(req, res) {
-     const posts = await postService.getAllPosts();
-     res.json(posts);
- }
+export async function getPosts(req, res) {
+    const {
+        sort,
+        grief_tag,
+        startDate,
+        endDate,
+        liked,
+        mine,
+    } = req.query;
+
+    const options = {
+        sort,
+        grief_tag,
+        startDate,
+        endDate,
+        liked: liked === 'true',
+        userId: mine === 'true' ? req.user.id : undefined,
+    };
+
+    const posts = await postService.getAllPosts(options);
+    res.json(posts);
+}
 
 export async function createPost(req, res) {
     // const { title, body, media_url, grief_tag } = req.body;


### PR DESCRIPTION
## Summary
- add query support in posts service for sorting and filtering
- expose query parameters in posts controller
- update PostsList component with filter UI and fetch logic

## Testing
- `npm test --silent`
- `(cd Server && npm test --silent)`

------
https://chatgpt.com/codex/tasks/task_e_68485a5fbe9c832d86ff9f75a2daf5b3